### PR TITLE
Fix loop mode disabling for short sliders

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -261,6 +261,7 @@
   /** Initialise a *single* Swiper instance inside its container. */
   function createSwiper(container) {
     const instanceOptions = getInstanceOptions(container);
+    const userDefinedLoop = Object.prototype.hasOwnProperty.call(instanceOptions, "loop");
     const swiperConfig = deepMerge({}, defaultSwiperOptions, instanceOptions);
 
     // user may fully override breakpoints
@@ -295,7 +296,7 @@
     else if (swiperConfig.breakpoints) {
       maxSpv = Math.max(...Object.values(swiperConfig.breakpoints).map((bp) => bp.slidesPerView || 1));
     }
-    if (slidesCount <= maxSpv) swiperConfig.loop = false;
+    if (!userDefinedLoop && slidesCount <= maxSpv) swiperConfig.loop = false;
 
     if (slidesCount <= 1) {
       swiperConfig.navigation = false;


### PR DESCRIPTION
## Summary
- track whether a slider explicitly requested loop mode
- keep loop enabled even when the slide count is below the maximum slides per view when explicitly set

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddafdeda3c8325aa60d0821e696803